### PR TITLE
Use Alpine Linux to built a smaller Docker image for Fab Manager

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,12 +5,16 @@ vendor/cache
 config/database.yml
 config/application.yml
 
-# Ignore the default SQLite database.
+# Ignore database files.
 db/*.sqlite3
 db/*.sqlite3-journal
+postgresql
+elasticsearch
+redis
 
 # Ignore all logfiles and tempfiles.
 log
+*.log
 tmp
 
 public/uploads
@@ -24,10 +28,17 @@ invoices
 
 .DS_Store
 
+# Development files
 .vagrant
 Vagrantfile
-
+provision
 .git*
-
 Dockerfile
 docker-compose*
+
+# Docs
+*.md
+doc
+
+# Modules
+node_modules


### PR DESCRIPTION
This addresses #144 
* Dockerfile with Ruby 2.3.8 Alpine as base.
* Ignore some extra files when sending the build context.

I managed to define the `Dockerfile` to build the image with Linux Alpine as base. I had no time test is thoroughly as using the image locally requires some tinkering with the configuration of the other services, but as far as I could assess the tasks for db creation, migration and seeding worked fine.

Just for comparison, the current image has a size of 1.67GB, while the Alpine based image has half the size, and on my tests, can be slimmed down to 680MB with the experimental `--squash` feature. (I don't know if it is available on Docker Hub).