### PR TITLE
Enable working with Docker in the Virtual Environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.network "forwarded_port", guest: port, host: port
   end
 
+  # nginx server
+  config.vm.network "forwarded_port", guest: 80, host: 8080
+
   # Configuration to allocate resources fro the virtual machine
   config.vm.provider 'virtualbox' do |vb|
     vb.customize ['modifyvm', :id, '--memory', '2048']
@@ -30,8 +33,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder '.', '/vagrant', type: 'virtualbox'
 
   # Copy default configuration files for the database conenction and the Rails application
-  config.vm.provision "file", source: "./config/database.yml.default",    destination: "/vagrant/config/database.yml"
+  config.vm.provision "file", source: "./config/database.yml.default", destination: "/vagrant/config/database.yml"
   config.vm.provision "file", source: "./config/application.yml.default", destination: "/vagrant/config/application.yml"
+
+  # Copy default configuration files to allow reviewing the Docker Compose integration
+  config.vm.provision "file", source: "./docker/docker-compose.yml", destination: "/home/vagrant/docker-compose.yml"
+  config.vm.provision "file", source: "./docker/env.example", destination: "/home/vagrant/config/env"
+  config.vm.provision "file", source: "./docker/nginx.conf.example", destination: "/home/vagrant/config/nginx/fabmanager.conf"
+  config.vm.provision "file", source: "./docker/elasticsearch.yml", destination: "/home/vagrant/elasticsearch/config/elasticsearch.yml"
+  config.vm.provision "file", source: "./docker/log4j2.properties", destination: "/home/vagrant/elasticsearch/config/log4j2.properties"
 
   ## Provision software dependencies
   config.vm.provision "shell", privileged: false, run: "once",

--- a/provision/box_setup.zsh
+++ b/provision/box_setup.zsh
@@ -166,6 +166,33 @@ install_ruby() {
 }
 
 ###
+# Install Docker
+docker()
+{
+  echo "* Setting up Docker... *********************************************** "
+
+  sudo apt-get install -y curl \
+    ntp \
+    ntpdate \
+    ca-certificates \
+    apt-transport-https \
+    software-properties-common
+
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  sudo apt-key fingerprint 0EBFCD88
+
+  sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  sudo apt-get update
+  sudo apt-get install -y docker-ce
+  sudo usermod -a -G docker $USER
+
+  echo "* Setting up Docker Compose ****************************************** "
+
+  sudo curl -L https://github.com/docker/compose/releases/download/1.21.2/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose
+  sudo chmod +x /usr/local/bin/docker-compose
+}
+
+###
 # Remove unused software
 clean_up() {
   echo "Removing unused software"

--- a/provision/box_tuning.zsh
+++ b/provision/box_tuning.zsh
@@ -31,3 +31,5 @@ setup() {
 }
 
 setup "$@"
+
+echo 'Virtual Environment is ready. Plase run `vagrant reload`.'


### PR DESCRIPTION
These are the changes for Vagrant and the provision scripts to allow building a Docker image from the sources and to use Docker Compose to test the complete set of services used by Fab Manager. 