### PR TITLE
Add missing ? to create? method name.

### DIFF
--- a/app/policies/training_policy.rb
+++ b/app/policies/training_policy.rb
@@ -8,7 +8,7 @@ class TrainingPolicy < ApplicationPolicy
     end
   end
 
-  def create
+  def create?
     user.admin?
   end
 


### PR DESCRIPTION
With this change, administrators can create new trainings. See #211.