### PR TITLE
(bug) Fix admin group being replaced in SSO authentication

### DIFF
--- a/app/models/concerns/single_sign_on_concern.rb
+++ b/app/models/concerns/single_sign_on_concern.rb
@@ -121,7 +121,7 @@ module SingleSignOnConcern
         logger.debug "mapping sso field #{field} with value=#{value}"
         # we do not merge the email field if its end with the special value '-duplicate' as this means
         # that the user is currently merging with the account that have the same email than the sso
-        set_data_from_sso_mapping(field, value) unless field == 'user.email' && value.end_with?('-duplicate')
+        set_data_from_sso_mapping(field, value) unless (field == 'user.email' && value.end_with?('-duplicate')) || (field == 'user.group_id' && user.admin?)
       end
 
       # run the account transfer in an SQL transaction to ensure data integrity


### PR DESCRIPTION
When SSO is enabled mapping the group id, the group is overridden even when the user is admin and is supposed to be in the "admins" group.

This bug causes errors such as "group_id : Unable to remove an administrator from his dedicated group" when updating the profile without changing anything.

This was not tested though, so let me know if there is anything I need to change.