### PR TITLE
(bug) Fix SSO data being overridden when it is empty and the user can change it

### DIFF
--- a/app/models/concerns/single_sign_on_concern.rb
+++ b/app/models/concerns/single_sign_on_concern.rb
@@ -40,8 +40,10 @@ module SingleSignOnConcern
     ## @param sso_mapping {String} must be of form 'user._field_' or 'profile._field_'. Eg. 'user.email'
     ## @param data {*} the data to put in the given key. Eg. 'user@example.com'
     def set_data_from_sso_mapping(sso_mapping, data)
+      return if data.nil? || data.blank? || mapped_from_sso&.include?(sso_mapping)
+
       if sso_mapping.to_s.start_with? 'user.'
-        self[sso_mapping[5..-1].to_sym] = data unless data.nil? || data.blank?
+        self[sso_mapping[5..-1].to_sym] = data
       elsif sso_mapping.to_s.start_with? 'profile.'
         case sso_mapping.to_s
         when 'profile.avatar'
@@ -67,10 +69,9 @@ module SingleSignOnConcern
           self.statistic_profile ||= StatisticProfile.new
           self.statistic_profile.birthday = data
         else
-          profile[sso_mapping[8..-1].to_sym] = data unless data.nil?
+          profile[sso_mapping[8..-1].to_sym] = data
         end
       end
-      return if data.nil? || data.blank? || mapped_from_sso&.include?(sso_mapping)
 
       self.mapped_from_sso = [mapped_from_sso, sso_mapping].compact.join(',')
     end
@@ -121,7 +122,7 @@ module SingleSignOnConcern
         logger.debug "mapping sso field #{field} with value=#{value}"
         # we do not merge the email field if its end with the special value '-duplicate' as this means
         # that the user is currently merging with the account that have the same email than the sso
-        set_data_from_sso_mapping(field, value) unless field == 'user.email' && value.end_with?('-duplicate')
+        set_data_from_sso_mapping(field, value) unless (field == 'user.email' && value.end_with?('-duplicate')) || (field == 'user.group_id' && user.admin?)
       end
 
       # run the account transfer in an SQL transaction to ensure data integrity

--- a/app/models/concerns/single_sign_on_concern.rb
+++ b/app/models/concerns/single_sign_on_concern.rb
@@ -40,7 +40,7 @@ module SingleSignOnConcern
     ## @param sso_mapping {String} must be of form 'user._field_' or 'profile._field_'. Eg. 'user.email'
     ## @param data {*} the data to put in the given key. Eg. 'user@example.com'
     def set_data_from_sso_mapping(sso_mapping, data)
-      return if data.nil? || data.blank? || mapped_from_sso&.include?(sso_mapping)
+      return if data.nil? || data.blank?
 
       if sso_mapping.to_s.start_with? 'user.'
         self[sso_mapping[5..-1].to_sym] = data
@@ -72,6 +72,8 @@ module SingleSignOnConcern
           profile[sso_mapping[8..-1].to_sym] = data
         end
       end
+
+      return if mapped_from_sso&.include?(sso_mapping)
 
       self.mapped_from_sso = [mapped_from_sso, sso_mapping].compact.join(',')
     end
@@ -122,7 +124,7 @@ module SingleSignOnConcern
         logger.debug "mapping sso field #{field} with value=#{value}"
         # we do not merge the email field if its end with the special value '-duplicate' as this means
         # that the user is currently merging with the account that have the same email than the sso
-        set_data_from_sso_mapping(field, value) unless (field == 'user.email' && value.end_with?('-duplicate')) || (field == 'user.group_id' && user.admin?)
+        set_data_from_sso_mapping(field, value) unless field == 'user.email' && value.end_with?('-duplicate')
       end
 
       # run the account transfer in an SQL transaction to ensure data integrity


### PR DESCRIPTION
When some data is not present in SSO, the user can change it (it is not present in `mapped_from_sso`), but as soon as they login again, the data is replaced.

This fixes this issue by using the same logic to add them in `mapped_from_sso` to actually map the property, also making all properties consistent, as all of them now ignore null properties.

I found this issue while testing the "birthday" property: the user was redirected every login to the profile completion page because when they logged in the birthday property was removed.