### PR TITLE
Allow searching by username

### DIFF
--- a/app/services/members/list_service.rb
+++ b/app/services/members/list_service.rb
@@ -54,7 +54,8 @@ class Members::ListService
                     .where("users.is_active = 'true'")
                     .limit(50)
       query.downcase.split(' ').each do |word|
-        members = members.where('lower(f_unaccent(profiles.first_name)) ~ :search OR ' \
+        members = members.where('lower(f_unaccent(users.username)) ~ :search OR ' \
+                                'lower(f_unaccent(profiles.first_name)) ~ :search OR ' \
                                 'lower(f_unaccent(profiles.last_name)) ~ :search',
                                 search: word)
       end


### PR DESCRIPTION
This PR adds the username as a searchable field for users, which is useful when an admin is reserving something for another user.

In our FabLAB, we are using the username as the student identification number. This feature is something I missed in #375, allowing to quickly register a reservation without the student full name.

Thank you.