### PR TITLE
(Bug) Fix (once again) admin users groups being overriden by SSO group_id

### DIFF
--- a/app/models/concerns/single_sign_on_concern.rb
+++ b/app/models/concerns/single_sign_on_concern.rb
@@ -124,7 +124,7 @@ module SingleSignOnConcern
         logger.debug "mapping sso field #{field} with value=#{value}"
         # we do not merge the email field if its end with the special value '-duplicate' as this means
         # that the user is currently merging with the account that have the same email than the sso
-        set_data_from_sso_mapping(field, value) unless (field == 'user.email' && value.end_with?('-duplicate')) || (field == 'user.group_id' && sso_user.admin?)
+        set_data_from_sso_mapping(field, value) unless (field == 'user.email' && value.end_with?('-duplicate')) || (field == 'user.group_id' && self.admin?)
       end
 
       # run the account transfer in an SQL transaction to ensure data integrity


### PR DESCRIPTION
When SSO is enabled mapping the group id, the group is overridden even when the user is admin and is supposed to be in the "admins" group.

This was "fixed" before in #376, which did not work. I think it's because it was checking whether the user is an admin based on the temporary user, and not the actual one. Please, can you check if this one is in the correct path?

Thank you