### PR TITLE
(Bug) Fix pt time formatting

### DIFF
--- a/config/locales/base.pt.yml
+++ b/config/locales/base.pt.yml
@@ -2,4 +2,4 @@ pt:
   time:
     formats:
       # See http://apidock.com/ruby/DateTime/strftime for a list of available directives
-      hour_minute: "%I:%M %p"
+      hour_minute: "%H:%M"


### PR DESCRIPTION
This PR fixes time formatting for the portuguese language. I couldn't find this file in Crowdin, that's why I have created this pull request instead.

In various parts of the platform, the date and time is displayed as two-parts:
- The start, containing the date and time
- The end, only containing the time

The issue is that the time format in both parts is different. The start one being in a 24h format, and the end one being in a 12h format.

Emails:
![Email](https://user-images.githubusercontent.com/1813032/192796824-4bec6008-a897-40fa-9414-3683504cf607.png)

Invoices:
![Invoice](https://user-images.githubusercontent.com/1813032/192797579-8e83d68e-00c0-4a01-8f43-c6059f3f4fd5.png)
