### PR TITLE
Fix tests in UTC negative timezones

### DIFF
--- a/test/fixtures/availabilities.yml
+++ b/test/fixtures/availabilities.yml
@@ -1,8 +1,8 @@
 
 availability_1:
   id: 1
-  start_at: <%= DateTime.current.utc.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= DateTime.current.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= DateTime.current.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= DateTime.current.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: training
   created_at: 2016-04-04 15:24:01.517486000 Z
   updated_at: 2016-04-04 15:24:01.517486000 Z
@@ -11,8 +11,8 @@ availability_1:
 
 availability_2:
   id: 2
-  start_at: <%= (DateTime.current + 1.day).utc.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 1.day).utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 1.day).change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 1.day).change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: training
   created_at: 2016-04-04 15:24:09.169364000 Z
   updated_at: 2016-04-04 15:24:09.169364000 Z
@@ -21,8 +21,8 @@ availability_2:
 
 availability_3:
   id: 3
-  start_at: <%= DateTime.current.utc.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= DateTime.current.utc.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= DateTime.current.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= DateTime.current.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: machines
   created_at: 2016-04-04 15:24:27.587583000 Z
   updated_at: 2016-04-04 15:24:27.587583000 Z
@@ -31,8 +31,8 @@ availability_3:
 
 availability_4:
   id: 4
-  start_at: <%= (DateTime.current + 1.day).utc.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 1.day).utc.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 1.day).change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 1.day).change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: machines
   created_at: 2016-04-04 15:24:44.044908000 Z
   updated_at: 2016-04-04 15:24:44.044908000 Z
@@ -41,8 +41,8 @@ availability_4:
 
 availability_5:
   id: 5
-  start_at: <%= (DateTime.current + 2.day).utc.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 2.day).utc.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 2.day).change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 2.day).change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: machines
   created_at: 2016-04-04 15:25:48.584444000 Z
   updated_at: 2016-04-04 15:25:48.584444000 Z
@@ -51,8 +51,8 @@ availability_5:
 
 availability_6:
   id: 6
-  start_at: <%= (DateTime.current + 3.day).utc.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 3.day).utc.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 3.day).change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 3.day).change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: machines
   created_at: 2016-04-04 15:26:17.953216000 Z
   updated_at: 2016-04-04 15:26:17.953216000 Z
@@ -61,8 +61,8 @@ availability_6:
 
 availability_7:
   id: 7
-  start_at: <%= (DateTime.current + 3.day).utc.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 3.day).utc.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 3.day).change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 3.day).change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: machines
   created_at: 2016-04-04 15:26:39.278627000 Z
   updated_at: 2016-04-04 15:26:39.278627000 Z
@@ -71,8 +71,8 @@ availability_7:
 
 availability_8:
   id: 8
-  start_at: <%= (DateTime.current + 2.day).utc.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 2.day).utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 2.day).change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 2.day).change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: training
   created_at: 2016-04-04 15:26:49.572724000 Z
   updated_at: 2016-04-04 15:26:49.572724000 Z
@@ -132,8 +132,8 @@ availability_13:
 
 availability_14:
   id: 14
-  start_at: <%= 20.days.from_now.utc.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 20.days.from_now.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 20.days.from_now.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 20.days.from_now.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: machines
   created_at: 2016-04-04 15:44:04.023557000 Z
   updated_at: 2016-04-04 15:44:04.023557000 Z
@@ -142,8 +142,8 @@ availability_14:
 
 availability_15:
   id: 15
-  start_at: <%= 40.days.from_now.utc.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 40.days.from_now.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 40.days.from_now.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 40.days.from_now.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: machines
   created_at: 2016-04-04 15:44:04.023557000 Z
   updated_at: 2016-04-04 15:44:04.023557000 Z
@@ -152,8 +152,8 @@ availability_15:
 
 availability_16:
   id: 16
-  start_at: <%= 80.days.from_now.utc.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 80.days.from_now.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 80.days.from_now.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 80.days.from_now.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: machines
   created_at: 2016-04-04 15:44:04.023557000 Z
   updated_at: 2016-04-04 15:44:04.023557000 Z
@@ -162,8 +162,8 @@ availability_16:
 
 availability_17:
   id: 17
-  start_at: <%= 10.days.from_now.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 12.days.from_now.utc.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 10.days.from_now.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 12.days.from_now.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: event
   created_at: 2016-04-04 15:44:04.023557000 Z
   updated_at: 2016-04-04 15:44:04.023557000 Z
@@ -172,8 +172,8 @@ availability_17:
 
 availability_18:
   id: 18
-  start_at: <%= 2.days.from_now.utc.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 2.days.from_now.utc.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 2.days.from_now.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 2.days.from_now.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: space
   created_at: 2017-02-15 15:53:35.154433000 Z
   updated_at: 2017-02-15 15:53:35.154433000 Z
@@ -182,8 +182,8 @@ availability_18:
 
 availability_19:
   id: 19
-  start_at: <%= 1.day.from_now.utc.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 1.day.from_now.utc.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 1.day.from_now.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 1.day.from_now.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: machines
   created_at: 2017-02-15 15:53:35.154433000 Z
   updated_at: 2017-02-15 15:53:35.154433000 Z
@@ -192,8 +192,8 @@ availability_19:
 
 availability_20:
   id: 20
-  start_at: <%= 10.days.ago.utc.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 10.days.ago.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 10.days.ago.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 10.days.ago.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   available_type: training
   created_at: 2022-07-18 12:38:21.616510000 Z
   updated_at: 2022-07-18 12:38:21.616510000 Z
@@ -202,8 +202,8 @@ availability_20:
 
 availability_21:
   id: 21
-  start_at: <%= 10.minutes.from_now.utc.strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (10.minutes.from_now + 1.hour).utc.strftime('%Y-%m-%d %H:%M:%S.%9N Z')  %>
+  start_at: <%= 10.minutes.from_now.strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (10.minutes.from_now + 1.hour).strftime('%Y-%m-%d %H:%M:%S.%9N Z')  %>
   available_type: space
   created_at: 2022-12-14 12:01:26.165110000 Z
   updated_at: 2022-12-14 12:01:26.165110000 Z

--- a/test/fixtures/slots.yml
+++ b/test/fixtures/slots.yml
@@ -17,240 +17,240 @@ slot_2:
 
 slot_9:
   id: 9
-  start_at: <%= DateTime.current.utc.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= DateTime.current.utc.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= DateTime.current.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= DateTime.current.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.880751'
   updated_at: '2022-07-12 15:18:43.880751'
   availability_id: 3
 
 slot_10:
   id: 10
-  start_at: <%= DateTime.current.utc.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= DateTime.current.utc.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= DateTime.current.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= DateTime.current.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.882957'
   updated_at: '2022-07-12 15:18:43.882957'
   availability_id: 3
 
 slot_11:
   id: 11
-  start_at: <%= DateTime.current.utc.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= DateTime.current.utc.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= DateTime.current.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= DateTime.current.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.884691'
   updated_at: '2022-07-12 15:18:43.884691'
   availability_id: 3
 
 slot_12:
   id: 12
-  start_at: <%= DateTime.current.utc.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= DateTime.current.utc.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= DateTime.current.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= DateTime.current.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.886431'
   updated_at: '2022-07-12 15:18:43.886431'
   availability_id: 3
 
 slot_13:
   id: 13
-  start_at: <%= DateTime.current.utc.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= DateTime.current.utc.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= DateTime.current.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= DateTime.current.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.888074'
   updated_at: '2022-07-12 15:18:43.888074'
   availability_id: 3
 
 slot_14:
   id: 14
-  start_at: <%= DateTime.current.utc.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= DateTime.current.utc.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= DateTime.current.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= DateTime.current.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.889691'
   updated_at: '2022-07-12 15:18:43.889691'
   availability_id: 3
 
 slot_15:
   id: 15
-  start_at: <%= (DateTime.current + 1.day).utc.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 1.day).utc.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 1.day).change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 1.day).change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.893096'
   updated_at: '2022-07-12 15:18:43.893096'
   availability_id: 4
 
 slot_16:
   id: 16
-  start_at: <%= (DateTime.current + 1.day).utc.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 1.day).utc.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 1.day).change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 1.day).change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.894777'
   updated_at: '2022-07-12 15:18:43.894777'
   availability_id: 4
 
 slot_17:
   id: 17
-  start_at: <%= (DateTime.current + 1.day).utc.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 1.day).utc.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 1.day).change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 1.day).change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.896423'
   updated_at: '2022-07-12 15:18:43.896423'
   availability_id: 4
 
 slot_18:
   id: 18
-  start_at: <%= (DateTime.current + 1.day).utc.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 1.day).utc.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 1.day).change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 1.day).change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.898021'
   updated_at: '2022-07-12 15:18:43.898021'
   availability_id: 4
 
 slot_19:
   id: 19
-  start_at: <%= (DateTime.current + 1.day).utc.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 1.day).utc.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 1.day).change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 1.day).change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.899592'
   updated_at: '2022-07-12 15:18:43.899592'
   availability_id: 4
 
 slot_20:
   id: 20
-  start_at: <%= (DateTime.current + 1.day).utc.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 1.day).utc.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 1.day).change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 1.day).change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.900938'
   updated_at: '2022-07-12 15:18:43.900938'
   availability_id: 4
 
 slot_21:
   id: 21
-  start_at: <%= (DateTime.current + 2.day).utc.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 2.day).utc.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 2.day).change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 2.day).change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.904013'
   updated_at: '2022-07-12 15:18:43.904013'
   availability_id: 5
 
 slot_22:
   id: 22
-  start_at: <%= (DateTime.current + 2.day).utc.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 2.day).utc.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 2.day).change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 2.day).change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.905470'
   updated_at: '2022-07-12 15:18:43.905470'
   availability_id: 5
 
 slot_23:
   id: 23
-  start_at: <%= (DateTime.current + 2.day).utc.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 2.day).utc.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 2.day).change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 2.day).change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.907030'
   updated_at: '2022-07-12 15:18:43.907030'
   availability_id: 5
 
 slot_24:
   id: 24
-  start_at: <%= (DateTime.current + 2.day).utc.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 2.day).utc.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 2.day).change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 2.day).change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.908585'
   updated_at: '2022-07-12 15:18:43.908585'
   availability_id: 5
 
 slot_25:
   id: 25
-  start_at: <%= (DateTime.current + 2.day).utc.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 2.day).utc.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 2.day).change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 2.day).change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.910138'
   updated_at: '2022-07-12 15:18:43.910138'
   availability_id: 5
 
 slot_26:
   id: 26
-  start_at: <%= (DateTime.current + 2.day).utc.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 2.day).utc.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 2.day).change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 2.day).change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.911643'
   updated_at: '2022-07-12 15:18:43.911643'
   availability_id: 5
 
 slot_27:
   id: 27
-  start_at: <%= (DateTime.current + 3.day).utc.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 3.day).utc.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 3.day).change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 3.day).change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.914664'
   updated_at: '2022-07-12 15:18:43.914664'
   availability_id: 6
 
 slot_28:
   id: 28
-  start_at: <%= (DateTime.current + 3.day).utc.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 3.day).utc.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 3.day).change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 3.day).change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.916047'
   updated_at: '2022-07-12 15:18:43.916047'
   availability_id: 6
 
 slot_29:
   id: 29
-  start_at: <%= (DateTime.current + 3.day).utc.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 3.day).utc.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 3.day).change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 3.day).change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.917304'
   updated_at: '2022-07-12 15:18:43.917304'
   availability_id: 6
 
 slot_30:
   id: 30
-  start_at: <%= (DateTime.current + 3.day).utc.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 3.day).utc.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 3.day).change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 3.day).change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.918798'
   updated_at: '2022-07-12 15:18:43.918798'
   availability_id: 6
 
 slot_31:
   id: 31
-  start_at: <%= (DateTime.current + 3.day).utc.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 3.day).utc.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 3.day).change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 3.day).change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.920194'
   updated_at: '2022-07-12 15:18:43.920194'
   availability_id: 6
 
 slot_32:
   id: 32
-  start_at: <%= (DateTime.current + 3.day).utc.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 3.day).utc.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 3.day).change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 3.day).change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.921662'
   updated_at: '2022-07-12 15:18:43.921662'
   availability_id: 6
 
 slot_33:
   id: 33
-  start_at: <%= (DateTime.current + 3.day).utc.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 3.day).utc.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 3.day).change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 3.day).change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.924285'
   updated_at: '2022-07-12 15:18:43.924285'
   availability_id: 7
 
 slot_34:
   id: 34
-  start_at: <%= (DateTime.current + 3.day).utc.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 3.day).utc.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 3.day).change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 3.day).change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.925669'
   updated_at: '2022-07-12 15:18:43.925669'
   availability_id: 7
 
 slot_35:
   id: 35
-  start_at: <%= (DateTime.current + 3.day).utc.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 3.day).utc.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 3.day).change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 3.day).change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.927038'
   updated_at: '2022-07-12 15:18:43.927038'
   availability_id: 7
 
 slot_36:
   id: 36
-  start_at: <%= (DateTime.current + 3.day).utc.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 3.day).utc.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 3.day).change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 3.day).change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.928407'
   updated_at: '2022-07-12 15:18:43.928407'
   availability_id: 7
 
 slot_37:
   id: 37
-  start_at: <%= (DateTime.current + 3.day).utc.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 3.day).utc.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 3.day).change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 3.day).change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.929907'
   updated_at: '2022-07-12 15:18:43.929907'
   availability_id: 7
 
 slot_38:
   id: 38
-  start_at: <%= (DateTime.current + 3.day).utc.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 3.day).utc.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 3.day).change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 3.day).change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.931295'
   updated_at: '2022-07-12 15:18:43.931295'
   availability_id: 7
@@ -297,240 +297,240 @@ slot_43:
 
 slot_44:
   id: 44
-  start_at:  <%= 20.days.from_now.utc.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at:  <%= 20.days.from_now.utc.change({:hour => 7}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at:  <%= 20.days.from_now.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at:  <%= 20.days.from_now.change({:hour => 7}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.942392'
   updated_at: '2022-07-12 15:18:43.942392'
   availability_id: 14
 
 slot_45:
   id: 45
-  start_at:  <%= 20.days.from_now.utc.change({:hour => 7}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at:  <%= 20.days.from_now.utc.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at:  <%= 20.days.from_now.change({:hour => 7}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at:  <%= 20.days.from_now.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.943779'
   updated_at: '2022-07-12 15:18:43.943779'
   availability_id: 14
 
 slot_46:
   id: 46
-  start_at:  <%= 20.days.from_now.utc.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at:  <%= 20.days.from_now.utc.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at:  <%= 20.days.from_now.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at:  <%= 20.days.from_now.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.945154'
   updated_at: '2022-07-12 15:18:43.945154'
   availability_id: 14
 
 slot_47:
   id: 47
-  start_at:  <%= 20.days.from_now.utc.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at:  <%= 20.days.from_now.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at:  <%= 20.days.from_now.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at:  <%= 20.days.from_now.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.946515'
   updated_at: '2022-07-12 15:18:43.946515'
   availability_id: 14
 
 slot_48:
   id: 48
-  start_at: <%= 40.days.from_now.utc.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 40.days.from_now.utc.change({:hour => 7}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 40.days.from_now.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 40.days.from_now.change({:hour => 7}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.949178'
   updated_at: '2022-07-12 15:18:43.949178'
   availability_id: 15
 
 slot_49:
   id: 49
-  start_at: <%= 40.days.from_now.utc.change({:hour => 7}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 40.days.from_now.utc.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 40.days.from_now.change({:hour => 7}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 40.days.from_now.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.950348'
   updated_at: '2022-07-12 15:18:43.950348'
   availability_id: 15
 
 slot_50:
   id: 50
-  start_at: <%= 40.days.from_now.utc.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 40.days.from_now.utc.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 40.days.from_now.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 40.days.from_now.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.951535'
   updated_at: '2022-07-12 15:18:43.951535'
   availability_id: 15
 
 slot_51:
   id: 51
-  start_at: <%= 40.days.from_now.utc.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 40.days.from_now.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 40.days.from_now.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 40.days.from_now.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.952864'
   updated_at: '2022-07-12 15:18:43.952864'
   availability_id: 15
 
 slot_52:
   id: 52
-  start_at: <%= 80.days.from_now.utc.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 80.days.from_now.utc.change({:hour => 7}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 80.days.from_now.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 80.days.from_now.change({:hour => 7}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.955443'
   updated_at: '2022-07-12 15:18:43.955443'
   availability_id: 16
 
 slot_53:
   id: 53
-  start_at: <%= 80.days.from_now.utc.change({:hour => 7}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 80.days.from_now.utc.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 80.days.from_now.change({:hour => 7}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 80.days.from_now.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.956657'
   updated_at: '2022-07-12 15:18:43.956657'
   availability_id: 16
 
 slot_54:
   id: 54
-  start_at: <%= 80.days.from_now.utc.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 80.days.from_now.utc.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 80.days.from_now.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 80.days.from_now.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.957811'
   updated_at: '2022-07-12 15:18:43.957811'
   availability_id: 16
 
 slot_55:
   id: 55
-  start_at: <%= 80.days.from_now.utc.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 80.days.from_now.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 80.days.from_now.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 80.days.from_now.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.959063'
   updated_at: '2022-07-12 15:18:43.959063'
   availability_id: 16
 
 slot_56:
   id: 56
-  start_at: <%= 10.days.from_now.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 12.days.from_now.utc.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 10.days.from_now.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 12.days.from_now.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:43.961319'
   updated_at: '2022-07-12 15:18:43.961319'
   availability_id: 17
 
 slot_112:
   id: 112
-  start_at: <%= 2.days.from_now.utc.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 2.days.from_now.utc.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 2.days.from_now.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 2.days.from_now.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.038089'
   updated_at: '2022-07-12 15:18:44.038089'
   availability_id: 18
 
 slot_113:
   id: 113
-  start_at: <%= 2.days.from_now.utc.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 2.days.from_now.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 2.days.from_now.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 2.days.from_now.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.039392'
   updated_at: '2022-07-12 15:18:44.039392'
   availability_id: 18
 
 slot_114:
   id: 114
-  start_at: <%= 2.days.from_now.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 2.days.from_now.utc.change({:hour => 11}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 2.days.from_now.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 2.days.from_now.change({:hour => 11}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.040522'
   updated_at: '2022-07-12 15:18:44.040522'
   availability_id: 18
 
 slot_115:
   id: 115
-  start_at: <%= 2.days.from_now.utc.change({:hour => 11}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 2.days.from_now.utc.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 2.days.from_now.change({:hour => 11}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 2.days.from_now.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.041937'
   updated_at: '2022-07-12 15:18:44.041937'
   availability_id: 18
 
 slot_116:
   id: 116
-  start_at: <%= 1.day.from_now.utc.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 1.day.from_now.utc.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 1.day.from_now.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 1.day.from_now.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.044421'
   updated_at: '2022-07-12 15:18:44.044421'
   availability_id: 19
 
 slot_117:
   id: 117
-  start_at: <%= 1.day.from_now.utc.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 1.day.from_now.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 1.day.from_now.change({:hour => 9}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 1.day.from_now.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.045689'
   updated_at: '2022-07-12 15:18:44.045689'
   availability_id: 19
 
 slot_118:
   id: 118
-  start_at: <%= 1.day.from_now.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 1.day.from_now.utc.change({:hour => 11}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 1.day.from_now.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 1.day.from_now.change({:hour => 11}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.047009'
   updated_at: '2022-07-12 15:18:44.047009'
   availability_id: 19
 
 slot_119:
   id: 119
-  start_at: <%= 1.day.from_now.utc.change({:hour => 11}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 1.day.from_now.utc.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 1.day.from_now.change({:hour => 11}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 1.day.from_now.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.048272'
   updated_at: '2022-07-12 15:18:44.048272'
   availability_id: 19
 
 slot_120:
   id: 120
-  start_at: <%= 1.day.from_now.utc.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 1.day.from_now.utc.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 1.day.from_now.change({:hour => 12}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 1.day.from_now.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.049599'
   updated_at: '2022-07-12 15:18:44.049599'
   availability_id: 19
 
 slot_121:
   id: 121
-  start_at: <%= 1.day.from_now.utc.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 1.day.from_now.utc.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 1.day.from_now.change({:hour => 13}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 1.day.from_now.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.050947'
   updated_at: '2022-07-12 15:18:44.050947'
   availability_id: 19
 
 slot_122:
   id: 122
-  start_at: <%= 1.day.from_now.utc.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 1.day.from_now.utc.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 1.day.from_now.change({:hour => 14}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 1.day.from_now.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.052817'
   updated_at: '2022-07-12 15:18:44.052817'
   availability_id: 19
 
 slot_123:
   id: 123
-  start_at: <%= 1.day.from_now.utc.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 1.day.from_now.utc.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 1.day.from_now.change({:hour => 15}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 1.day.from_now.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.054966'
   updated_at: '2022-07-12 15:18:44.054966'
   availability_id: 19
 
 slot_124:
   id: 124
-  start_at: <%= 1.day.from_now.utc.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 1.day.from_now.utc.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 1.day.from_now.change({:hour => 16}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 1.day.from_now.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.057217'
   updated_at: '2022-07-12 15:18:44.057217'
   availability_id: 19
 
 slot_125:
   id: 125
-  start_at: <%= 1.day.from_now.utc.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 1.day.from_now.utc.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 1.day.from_now.change({:hour => 17}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 1.day.from_now.change({:hour => 18}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.059135'
   updated_at: '2022-07-12 15:18:44.059135'
   availability_id: 19
 
 slot_126:
   id: 126
-  start_at: <%= DateTime.current.utc.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= DateTime.current.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= DateTime.current.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= DateTime.current.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.061887'
   updated_at: '2022-07-12 15:18:44.061887'
   availability_id: 1
 
 slot_127:
   id: 127
-  start_at: <%= (DateTime.current + 1.day).utc.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 1.day).utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 1.day).change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 1.day).change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.063528'
   updated_at: '2022-07-12 15:18:44.063528'
   availability_id: 2
 
 slot_128:
   id: 128
-  start_at: <%= (DateTime.current + 2.day).utc.change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (DateTime.current + 2.day).utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= (DateTime.current + 2.day).change({:hour => 6}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (DateTime.current + 2.day).change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-12 15:18:44.065114'
   updated_at: '2022-07-12 15:18:44.065114'
   availability_id: 8
@@ -561,16 +561,16 @@ slot_131:
 
 slot_132:
   id: 132
-  start_at: <%= 10.days.ago.utc.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= 10.days.ago.utc.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  start_at: <%= 10.days.ago.change({:hour => 8}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= 10.days.ago.change({:hour => 10}).strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
   created_at: '2022-07-18 12:38:21.616510'
   updated_at: '2022-07-18 12:38:21.616510'
   availability_id: 20
 
 slot_133:
   id: 133
-  start_at: <%= 10.minutes.from_now.utc.strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
-  end_at: <%= (10.minutes.from_now + 1.hour).utc.strftime('%Y-%m-%d %H:%M:%S.%9N Z')  %>
+  start_at: <%= 10.minutes.from_now.strftime('%Y-%m-%d %H:%M:%S.%9N Z') %>
+  end_at: <%= (10.minutes.from_now + 1.hour).strftime('%Y-%m-%d %H:%M:%S.%9N Z')  %>
   created_at: '2022-12-14 12:01:26.165110'
   updated_at: '2022-12-14 12:01:26.165110'
   availability_id: 21


### PR DESCRIPTION
Currently, the test fixtures are inserted with the UTC timezone, while tests run in the environment timezone, which makes a few tests not reproducible in every environment.

This PR removes the UTC timezone from the fixtures, making all tests pass as expected.