### PR TITLE
(Bug) Fix event date being changed to a day before from the browser timezone

### DIFF
--- a/app/frontend/src/javascript/components/form/form-input.tsx
+++ b/app/frontend/src/javascript/components/form/form-input.tsx
@@ -65,7 +65,7 @@ export const FormInput = <TFieldValues extends FieldValues, TInputType>({ id, re
         return num;
       }
       if (type === 'date') {
-        const date: Date = new Date(value);
+        const date: Date = new Date(value + 'T00:00:00');
         if (Number.isNaN(date) && nullable) {
           return null;
         }


### PR DESCRIPTION
This PR fixes a bug from date inputs in which the date was always set to a day before with UTC negative timezones.

The javascript `Date` object works in the local browser timezone. Initializing it with `new Date('2023-03-17')` in a UTC-3 timezone would return the date `2023-03-16 21:00:00` which means the resulting date would be `2023-03-16`. But in a UTC positive timezone, such as UTC+1, the date will be `2023-03-17 01:00:00`, which would be correctly.

This fix normalizes the time to UTC, making it consistent across different browser timezones.